### PR TITLE
Fix for 1.9.2's $LOAD_APTH

### DIFF
--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -1,6 +1,6 @@
 require 'rake/gempackagetask'
 require 'yaml'
-require 'lib/hijack'
+require './lib/hijack'
 
 task :clean => :clobber_package
 


### PR DESCRIPTION
## Problem

1.9.2's $LOAD_APTH does not include current directory,
and tasks/gem.rake made an following error:

```
rake aborted!
no such file to load -- lib/hijack
```
## Solution

I solve it as follows:

```
require 'lib/hijack'
```

↓

```
require './lib/hijack'
```
